### PR TITLE
Add fine-grained logging for write() timing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.lettuce</groupId>
     <artifactId>lettuce-core</artifactId>
-    <version>6.0.1.RELEASE</version>
+    <version>6.0.1.DEBUG</version>
     <packaging>jar</packaging>
 
     <name>Lettuce</name>


### PR DESCRIPTION
This branch introduces some temporary debug logging to track down which part of calls to `write()` are taking longer than expected in support of https://github.com/lettuce-io/lettuce-core/issues/1494.